### PR TITLE
Fix typo in footer text

### DIFF
--- a/parts/include/footer.php
+++ b/parts/include/footer.php
@@ -8,7 +8,7 @@
                 <div class="col-xs-6 col-sm-6">
 
                     <p class="footer-copyright text-right">
-                    Mentions légals
+                    Mentions légales
                      </p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- fix typo for legal notice text in the footer

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684c6edf8888832daba7f028e4b69df0